### PR TITLE
fix: setting /proc/sys/kernel/pid_max for proot

### DIFF
--- a/.github/workflows/golang_validation.yml
+++ b/.github/workflows/golang_validation.yml
@@ -43,8 +43,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1
-    - name: Set process id limit for 32-bit builds depending on aosp-libs
-      run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
     - name: Enable zram
       if: ${{ steps.build-info.outputs.skip-building != 'true' }}
       uses: ./.github/actions/zram

--- a/.github/workflows/package_updates.yml
+++ b/.github/workflows/package_updates.yml
@@ -104,8 +104,6 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.TERMUXBOT2_TOKEN }}
-      - name: Set process id limit for 32-bit builds depending on aosp-libs
-        run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
       - name: Enable zram
         uses: ./.github/actions/zram
         with:

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -47,8 +47,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1000
-    - name: Set process id limit for 32-bit builds depending on aosp-libs
-      run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
 
     - name: Gather build summary
       id: build-info

--- a/.github/workflows/zig_validation.yml
+++ b/.github/workflows/zig_validation.yml
@@ -43,8 +43,6 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 1
-    - name: Set process id limit for 32-bit builds depending on aosp-libs
-      run: echo 65535 | sudo tee /proc/sys/kernel/pid_max
     - name: Enable zram
       if: ${{ steps.build-info.outputs.skip-building != 'true' }}
       uses: ./.github/actions/zram

--- a/scripts/run-docker.sh
+++ b/scripts/run-docker.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e -u
+set -eou pipefail
 
 TERMUX_SCRIPTDIR=$(cd "$(realpath "$(dirname "$0")")"; cd ..; pwd)
 : ${TERMUX_BUILDER_IMAGE_NAME:=ghcr.io/termux/package-builder}
@@ -171,6 +171,24 @@ $SUDO docker start $CONTAINER_NAME >/dev/null 2>&1 || {
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo chown -R $(id -u):$(id -g) /data
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo usermod -u $(id -u) builder
 			$SUDO docker exec $DOCKER_TTY $TERMUX_DOCKER_EXEC_EXTRA_ARGS $CONTAINER_NAME sudo groupmod -g $(id -g) builder
+		fi
+		echo "Changing /proc/sys/kernel/pid_max to 65535 for packages that need to run native executables using proot (for 32-bit architectures)"
+		if [[ "$($SUDO docker exec $CONTAINER_NAME cat /proc/sys/kernel/pid_max)" -le 65535 ]]; then
+			echo "No need to change /proc/sys/kernel/pid_max, current value is $($SUDO docker exec $DOCKER_TTY $CONTAINER_NAME cat /proc/sys/kernel/pid_max)"
+		else
+			# On kernel versions >= 6.14, the pid_max value is pid namespaced, so we need to set it in the container namespace instead of host.
+			# But some distributions may backport the pid namespacing to older kernels, so we check whether it's effective by checking the value in the container after setting it.
+			$SUDO docker run --privileged --pid="container:$CONTAINER_NAME" --rm "$TERMUX_BUILDER_IMAGE_NAME" sh -c "echo 65535 | sudo tee /proc/sys/kernel/pid_max > /dev/null" || :
+			if [[ "$($SUDO docker exec $CONTAINER_NAME cat /proc/sys/kernel/pid_max)" -eq 65535 ]]; then
+				echo "Successfully changed /proc/sys/kernel/pid_max for container namespace"
+			else
+				echo "Failed to change /proc/sys/kernel/pid_max for container, failing back to setting it on host..."
+				if ( echo 65535 | sudo tee /proc/sys/kernel/pid_max >/dev/null ); then
+					echo "Successfully changed /proc/sys/kernel/pid_max on host, but it may affect other processes on the host system"
+				else
+					echo "Failed to change /proc/sys/kernel/pid_max on host as well, some packages that need to run native executables using proot (for 32-bit architectures) may not work properly"
+				fi
+			fi
 		fi
 	fi
 }


### PR DESCRIPTION
I've tested this on Linux 6.18 shipped by Arch. I wanted to check if this is working on users who have kernel versions < 6.14. As pid_max value isn't namespaced on older kernels.

Also this changes the place where we change the pid_max value from GitHub Actions workflow script to `./scripts/run-docker.sh`
